### PR TITLE
Delivery order misunderstood

### DIFF
--- a/draft-nandakumar-moq-scenarios.md
+++ b/draft-nandakumar-moq-scenarios.md
@@ -333,3 +333,15 @@ rate.
 This can result in scenarios where very small audio objects are sent at
 a rate of several hundreds packets per second with a high network loss
 rate.
+
+# Security and Privacy Considerations
+
+This document provides an abstract analysis of MoQ scenarios, but does
+not detail any security considerations.
+
+
+# IANA Considerations
+
+This document makes no request of IANA.
+
+-- back


### PR DESCRIPTION
A couple of subsections were based on misunderstanding of the "delivery order" approach used in WARP.
Exchanges on the MoQ mailing list have cleared those misunderstanding, leading to these corrections.